### PR TITLE
Fix: Add null checks for parent_object

### DIFF
--- a/addons/tween_composer/tween_composer.gd
+++ b/addons/tween_composer/tween_composer.gd
@@ -188,7 +188,9 @@ func _compose_tween() -> void:
 		
 		if !tw_step.active:
 			continue
-		
+		if !parent_object:
+			continue
+
 		# Saving initial value of property to _initial_values dictionary
 		if _initial_values.has(tw_step.property_name) == false: # Avoid duplicates, only get first value
 			_initial_values[tw_step.property_name] = parent_object.get_indexed(tw_step.property_name)
@@ -377,6 +379,8 @@ func _hide_parent() -> void:
 
 func _show_parent() -> void:
 	# INFO: Toggling "visible" in Control nodes can mess with the UI position, so the solution was to "turn invisible" instead.
+	if !parent_object:
+		return
 	if parent_object is Control:
 		parent_object.modulate = Color(1.0, 1.0, 1.0, 1.0)
 	else:


### PR DESCRIPTION
Not sure if this is the ideal solution (just a quick fix from me, feel free to close and fix properly) but I'm often finding Tween Composer dies at runtime because of missing `parent_object` after moving / editing it in the inspector / scene tree.
